### PR TITLE
Trim all spaces around configuration

### DIFF
--- a/get-aws-profile.sh
+++ b/get-aws-profile.sh
@@ -24,7 +24,7 @@ cfg_parser ()
   ini=( ${ini[*]//\#*/} )     # remove comments #
   ini=( ${ini[*]/\	=/=} )  # remove tabs before =
   ini=( ${ini[*]/=\	/=} )   # remove tabs be =
-  ini=( ${ini[*]/\ =\ /=} )   # remove anything with a space around  = 
+  ini=( ${ini[*]/\ *=\ /=} )   # remove anything with a space around  =
   ini=( ${ini[*]/#[/\}$'\n'cfg.section.} ) # set section prefix
   ini=( ${ini[*]/%]/ \(} )    # convert text2function (1)
   ini=( ${ini[*]/=/=\( } )    # convert item to array


### PR DESCRIPTION
In case your ~/.aws/credentials file is neatly formatted like:
```
[default]
aws_access_key_id     = blah
aws_secret_access_key = blahblah
```